### PR TITLE
upgrade stack lts to 19.1

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,17 +1,14 @@
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/26.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/1.yaml
 
 packages:
   - .
 
 extra-deps:
-  - opaleye-0.9.1.0
+  - co-log-core-0.3.1.0
   - postgresql-error-codes-1.0.1
-  - rel8-1.3.1.0
-  - servant-0.19
-  - servant-client-0.19
-  - servant-client-core-0.19
-  - servant-server-0.19
+  - tomland-1.3.3.1
+  - validation-selective-0.1.0.1
   - git: git@github.com:haskell-servant/servant.git
     commit: d05da71f09be08131d29a2c17f613a4bd71faea2
     subdirs:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: opaleye-0.9.1.0@sha256:b7b3e086c62319ed929c70874eeda833833c957d3c5431888c8605ae1b9122fa,5837
+    hackage: co-log-core-0.3.1.0@sha256:9794bdedd1391decd0e22bdfe2b11abcb42e6cff7a4531e1f8882890828f4e63,3816
     pantry-tree:
-      size: 5662
-      sha256: 770075682b00589dd4bb62d2f8239eeca41d1484db1b957b1c9a13c148dd88ba
+      size: 584
+      sha256: d4cc089c40c5052ee02f91eafa567e0a239908aabc561dfa6080ba3bfc8c25bd
   original:
-    hackage: opaleye-0.9.1.0
+    hackage: co-log-core-0.3.1.0
 - completed:
     hackage: postgresql-error-codes-1.0.1@sha256:34ce40401dc21762996dadd38336436f40a09da95ad3309ba6dc506d707cff11,1413
     pantry-tree:
@@ -19,40 +19,19 @@ packages:
   original:
     hackage: postgresql-error-codes-1.0.1
 - completed:
-    hackage: rel8-1.3.1.0@sha256:82292d07f590c92b256f512347bb410989501711d47fdd2b43823f6467169f03,5114
+    hackage: tomland-1.3.3.1@sha256:83a8fd26a97164100541f7b26aa40ffdc6f230b21e94cbb3eae1fb7093c4356e,8924
     pantry-tree:
-      size: 9026
-      sha256: 7fbfd8f7ce8a72348b9345831a1aeea2fc5bf17cdd6080106334d6962efcd889
+      size: 6430
+      sha256: 0e3bdbd32955944c3ee9ff0f47dc765d25ab6be4a336c6d735eed8eb9bc8ce27
   original:
-    hackage: rel8-1.3.1.0
+    hackage: tomland-1.3.3.1
 - completed:
-    hackage: servant-0.19@sha256:9f1145d48c049e5d39d8314bc0458d15e7767b8bc871eb1f2177b9fd29101272,5371
+    hackage: validation-selective-0.1.0.1@sha256:9a5aa8b801efc6a4ffb120e1b28e80c5f7d090043be56bba11222cd20c393044,3621
     pantry-tree:
-      size: 2802
-      sha256: da515b079d6e1d1aa41e5c04af988fe36ac295c7ec94b0d0f4a76bc7972a379c
+      size: 696
+      sha256: bf72fe4304690da4b5bc6e5218b0f90b5613e7d658f3ce31731816a423fcbca6
   original:
-    hackage: servant-0.19
-- completed:
-    hackage: servant-client-0.19@sha256:8c0c4ee78e1d95a0bee22602c24cff104a1ce3a309b24697d23e8bfc738d5755,4737
-    pantry-tree:
-      size: 1435
-      sha256: 247a61e92707e119160245713add81f1fffd328a595997917c299c0dbb1d3130
-  original:
-    hackage: servant-client-0.19
-- completed:
-    hackage: servant-client-core-0.19@sha256:58f14b579b0afa0d4ede8457d6d5dc6d222da1b556b81177779522edc054183a,3659
-    pantry-tree:
-      size: 1446
-      sha256: 02cced10bfcb14f15fe9afccc58da36decd56d0af12e333bada47c3414cd92ec
-  original:
-    hackage: servant-client-core-0.19
-- completed:
-    hackage: servant-server-0.19@sha256:d9636357e6f3db963e35418456607d0020e4e0c21df72b93e50fd5b9aa252995,5506
-    pantry-tree:
-      size: 2614
-      sha256: 626b78189a43285439c5db1eb1b2ab0e29e85396f8f5766220399060228fba27
-  original:
-    hackage: servant-server-0.19
+    hackage: validation-selective-0.1.0.1
 - completed:
     subdir: servant-auth/servant-auth-server
     name: servant-auth-server
@@ -68,8 +47,8 @@ packages:
     commit: d05da71f09be08131d29a2c17f613a4bd71faea2
 snapshots:
 - completed:
-    size: 590102
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/26.yaml
-    sha256: e76d109964d9335abb412e22139c5bce3078be290ac6d90b8ecea6cc009bb198
+    size: 617355
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/1.yaml
+    sha256: cbd5e8593869445794924668479b5bd9f1738d075898623dceacc13b2576b6e3
   original:
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/26.yaml
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/1.yaml


### PR DESCRIPTION
servant packages are now using version 0.19

on the other hand, Kowainik packages are no more on Stackage and we have to add them manually