### PR TITLE
Readability refactors

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -20,6 +20,6 @@ main = do
 
   let (Port port) = apiPort . apiConfig $ appConfig
       services = AppServices.start dbHandle jwk
-      application = Middleware.withMiddlewares (app services)
+      application = Middleware.apply (app services)
 
   Warp.run port application

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module Main where
 
@@ -7,31 +6,27 @@ import Api.AppServices (appServices)
 import Api.Application (app)
 import Api.Config (Port (..), apiConfig, apiPort)
 import qualified Api.Config as Config
-import CLIOptions (CLIOptions (configPath, jwkPath))
+import CLIOptions (CLIOptions (configPath))
 import qualified CLIOptions
-import Control.Exception (catch)
-import Crypto.JOSE.JWK (JWK)
-import Data.ByteString.Char8 (writeFile)
 import Data.Function ((&))
 import Network.Wai (Middleware)
 import qualified Network.Wai.Handler.Warp as Warp
 import Network.Wai.Middleware.Cors (cors, corsRequestHeaders, simpleCorsResourcePolicy)
 import Network.Wai.Middleware.RequestLogger (logStdoutDev)
-import Servant.Auth.Server (fromSecret, generateSecret, readKey)
-import Prelude hiding (writeFile)
 import qualified Tagger.Database as DB
+import qualified Tagger.JWK as JWK
 
 main :: IO ()
 main = do
   inputOptions <- CLIOptions.parse
   config <- Config.load (configPath inputOptions)
   dbHandle <- DB.new (DB.parseConfig config)
-  jsonWebKey <- setupJWK inputOptions
+  jsonWebKey <- JWK.setup inputOptions
   let port = apiPort . apiConfig $ config
 
   runApp jsonWebKey port dbHandle
 
-runApp :: JWK -> Port -> DB.Handle -> IO ()
+runApp :: JWK.JWK -> Port -> DB.Handle -> IO ()
 runApp jwk (Port port) dbHandle =
   let services = appServices dbHandle jwk
       application = app services & corsMiddleware & logStdoutDev
@@ -41,17 +36,3 @@ corsMiddleware :: Network.Wai.Middleware
 corsMiddleware =
   let headers = ["Authorization", "Content-Type"]
    in cors (const . Just $ simpleCorsResourcePolicy {corsRequestHeaders = headers})
-
-setupJWK :: CLIOptions -> IO JWK
-setupJWK =
-  jwtKey . jwkPath
-
-jwtKey :: FilePath -> IO JWK
-jwtKey path = do
-  -- try to retrieve the JWK from file
-  catch (readKey path) $ \(_ :: IOError) -> do
-    -- if the file does not exist or does not contain a valid key, we generate one
-    key <- generateSecret
-    -- and we store it
-    writeFile path key
-    pure $ fromSecret key

--- a/app/Middleware.hs
+++ b/app/Middleware.hs
@@ -1,14 +1,14 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Middleware (withMiddlewares) where
+module Middleware (apply) where
 
+import qualified Network.Wai as Wai (Application, Middleware)
 import Network.Wai.Middleware.Cors (cors, corsRequestHeaders, simpleCorsResourcePolicy)
 import Network.Wai.Middleware.RequestLogger (logStdoutDev)
-import qualified Network.Wai as Wai (Application, Middleware)
 
-withMiddlewares :: Wai.Application -> Wai.Application
-withMiddlewares =
- corsMiddleware . logStdoutDev
+apply :: Wai.Application -> Wai.Application
+apply =
+  corsMiddleware . logStdoutDev
 
 corsMiddleware :: Wai.Middleware
 corsMiddleware =

--- a/app/Middleware.hs
+++ b/app/Middleware.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Middleware (withMiddlewares) where
+
+import Network.Wai.Middleware.Cors (cors, corsRequestHeaders, simpleCorsResourcePolicy)
+import Network.Wai.Middleware.RequestLogger (logStdoutDev)
+import qualified Network.Wai as Wai (Application, Middleware)
+
+withMiddlewares :: Wai.Application -> Wai.Application
+withMiddlewares =
+ corsMiddleware . logStdoutDev
+
+corsMiddleware :: Wai.Middleware
+corsMiddleware =
+  let headers = ["Authorization", "Content-Type"]
+   in cors (const . Just $ simpleCorsResourcePolicy {corsRequestHeaders = headers})

--- a/src/Api/AppServices.hs
+++ b/src/Api/AppServices.hs
@@ -1,127 +1,128 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TupleSections #-}
 
-module Api.AppServices where
+module Api.AppServices
+  ( AppServices (..),
+    appServices,
+    connectedContentRepository,
+    connectedUserRepository,
+    connectedAuthenticateUser,
+    encryptedPasswordManager,
+  )
+where
 
-import qualified Infrastructure.Authentication.AuthenticateUser as Auth (AuthenticateUser(AuthenticateUser), AuthenticationError(AuthenticationQueryError), authenticateUser, hoistAuthenticateUser)
-import Infrastructure.Authentication.PasswordManager (PasswordManager, PasswordManagerError(..), hoistPasswordManager, bcryptPasswordManager)
-import Infrastructure.Logging.Logger (messageLogger, provideContext)
-import Infrastructure.Persistence.PostgresContentRepository (postgresContentRepository)
-import Infrastructure.Persistence.PostgresUserRepository (postgresUserRepository, UserRepositoryError (DuplicateUserName))
-import Tagger.ContentRepository (ContentRepository, hoistContentRepository)
-import Tagger.UserRepository (UserRepository, hoistUserRepository)
-
--- base
 import Control.Monad ((<=<))
+import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
-import Prelude hiding (log)
-
--- co-log-core
-import Colog.Core ((<&), LogAction, Severity(..))
-
--- hasql
+import Control.Monad.Trans.Except (ExceptT, runExceptT)
+import Crypto.JOSE.JWK (JWK)
 import Hasql.Connection (Connection)
 import Hasql.Session (QueryError)
-
--- jose
-import Crypto.JOSE.JWK (JWK)
-
--- mtl
-import Control.Monad.Except (throwError)
-
--- servant-auth-server
+import qualified Infrastructure.Authentication.AuthenticateUser as Auth
+import Infrastructure.Authentication.PasswordManager
+  ( PasswordManager,
+    PasswordManagerError (..),
+    bcryptPasswordManager,
+  )
+import qualified Infrastructure.Authentication.PasswordManager as PasswordManager
+import Infrastructure.Logging.Logger
+  ( Severity (..),
+    SeverityLogger,
+    messageLogger,
+    provideContext,
+    (<&),
+  )
+import Infrastructure.Persistence.PostgresContentRepository (postgresContentRepository)
+import Infrastructure.Persistence.PostgresUserRepository (UserRepositoryError (DuplicateUserName), postgresUserRepository)
+import Servant (Handler, err401, err403, err500)
 import Servant.Auth.Server (JWTSettings, defaultJWTSettings)
+import Tagger.ContentRepository (ContentRepository)
+import qualified Tagger.ContentRepository as ContentRepository
+import Tagger.UserRepository (UserRepository)
+import qualified Tagger.UserRepository as UserRepository
+import Prelude hiding (log)
 
--- servant-server
-import Servant (Handler, err500, err401, err403)
-
--- transformers
-import Control.Monad.Trans.Except (ExceptT, runExceptT)
-
--- |
 -- Collection of services needed by the application to work
 data AppServices = AppServices
-  { jwtSettings       :: JWTSettings
-  , passwordManager   :: PasswordManager Handler
-  , contentRepository :: ContentRepository Handler
-  , userRepository    :: UserRepository Handler
-  , authenticateUser  :: Auth.AuthenticateUser Handler
+  { jwtSettings :: JWTSettings,
+    passwordManager :: PasswordManager Handler,
+    contentRepository :: ContentRepository Handler,
+    userRepository :: UserRepository Handler,
+    authenticateUser :: Auth.AuthenticateUser Handler
   }
 
--- |
--- 'LogAction' which accepts any 'Show'able data type and a 'Severity'
-type SeverityLogger = forall a. Show a => LogAction Handler (Severity, a)
+type Log = SeverityLogger Handler
 
--- |
+-- Creates all the services needed by the application, creating a different contexts for the logger of each service
+appServices :: Connection -> JWK -> AppServices
+appServices connection key =
+  let logContext name = provideContext name messageLogger
+      passwordManager' = encryptedPasswordManager (logContext "PasswordManager") $ defaultJWTSettings key
+      dbUserRepository = postgresUserRepository connection
+   in AppServices
+        { jwtSettings = defaultJWTSettings key,
+          passwordManager = passwordManager',
+          contentRepository = connectedContentRepository (logContext "ContentRepository") (postgresContentRepository connection),
+          userRepository = connectedUserRepository (logContext "UserRepository") dbUserRepository,
+          authenticateUser = connectedAuthenticateUser (logContext "AuthenticateUser") dbUserRepository passwordManager'
+        }
+
 -- Lifts a computation from 'ExceptT e IO' to 'Handler a' using the provided 'handleError' function
 eitherTToHandler :: (e -> Handler a) -> ExceptT e IO a -> Handler a
 eitherTToHandler handleError = either handleError pure <=< liftIO . runExceptT
 
--- |
--- Lifts a 'ContentRepository' fo the 'Handler' monad, handling all errors by logging them and returning a 500 response
-connectedContentRepository :: SeverityLogger -> ContentRepository (ExceptT QueryError IO) -> ContentRepository Handler
-connectedContentRepository log = hoistContentRepository (eitherTToHandler $ (>> throwError err500) . (log <&) . (Error ,))
+-- Lifts a 'ContentRepository' to the 'Handler' monad, handling all errors by logging them and returning a 500 response
+connectedContentRepository :: Log -> ContentRepository (ExceptT QueryError IO) -> ContentRepository Handler
+connectedContentRepository log = ContentRepository.hoist (eitherTToHandler $ (>> throwError err500) . (log <&) . (Error,))
 
--- |
--- Lifts a 'UserRepository' fo the 'Handler' monad, handling all errors by logging them and returning a 500 response
-connectedUserRepository :: SeverityLogger -> UserRepository (ExceptT UserRepositoryError IO) -> UserRepository Handler
-connectedUserRepository log = hoistUserRepository $ eitherTToHandler handleUserRepositoryError-- (eitherTToHandler $ (>> throwError err500) . (log <&) . (Error ,))
+-- Lifts a 'UserRepository' to the 'Handler' monad, handling all errors by logging them and returning a 500 response
+connectedUserRepository ::
+  Log ->
+  UserRepository (ExceptT UserRepositoryError IO) ->
+  UserRepository Handler
+connectedUserRepository log = UserRepository.hoist $ eitherTToHandler handleUserRepositoryError
   where
     handleUserRepositoryError :: UserRepositoryError -> Handler a
-    -- If the database error concerns a duplicate user, we return a 403 response
-    handleUserRepositoryError (DuplicateUserName e) = do
-      log <& (Warning, DuplicateUserName e)
-      throwError err403
-    -- Otherwise, we return a 500 response
-    handleUserRepositoryError e                     = do
-      log <& (Error, e)
-      throwError err500
+    handleUserRepositoryError = \case
+      (DuplicateUserName e) -> do
+        log <& (Warning, DuplicateUserName e)
+        throwError err403
+      e -> do
+        log <& (Error, e)
+        throwError err500
 
--- |
 -- Creates an 'AuthenticateUser' service injecting its dependencies and handling errors
-connectedAuthenticateUser :: SeverityLogger -> UserRepository (ExceptT UserRepositoryError IO) -> PasswordManager Handler -> Auth.AuthenticateUser Handler
-connectedAuthenticateUser log userRepository' passwordManager'
-  = Auth.hoistAuthenticateUser (eitherTToHandler handleAuthenticationError)
-  . Auth.AuthenticateUser
-  $ Auth.authenticateUser userRepository' passwordManager'
-    where
-      handleAuthenticationError :: Auth.AuthenticationError -> Handler a
-      -- If there was an error at the database level, we return a 500 response
-      handleAuthenticationError (Auth.AuthenticationQueryError e) = do
+connectedAuthenticateUser :: Log -> UserRepository (ExceptT UserRepositoryError IO) -> PasswordManager Handler -> Auth.AuthenticateUser Handler
+connectedAuthenticateUser log userRepository' passwordManager' =
+  Auth.hoist (eitherTToHandler handleAuthenticationError)
+    . Auth.AuthenticateUser
+    $ Auth.authenticateUser userRepository' passwordManager'
+  where
+    handleAuthenticationError :: Auth.AuthenticationError -> Handler a
+    handleAuthenticationError = \case
+      -- If there was an error at the database level, return a 500 response
+      Auth.AuthenticationQueryError e -> do
         log <& (Error, Auth.AuthenticationQueryError e)
         throwError err500
-        -- In other cases, there was an authentication error and we return a 401 response
-      handleAuthenticationError e = do
+
+      -- Otherwise there was an authentication error, return a 401 response
+      e -> do
         log <& (Warning, e)
         throwError err401
 
--- |
 -- Creates a 'PasswordManager' service injecting its dependencies and handling errors
-encryptedPasswordManager :: SeverityLogger -> JWTSettings -> PasswordManager Handler
-encryptedPasswordManager log = hoistPasswordManager (eitherTToHandler handlePasswordManagerError) . bcryptPasswordManager
+encryptedPasswordManager :: Log -> JWTSettings -> PasswordManager Handler
+encryptedPasswordManager log = PasswordManager.hoist (eitherTToHandler handlePasswordManagerError) . bcryptPasswordManager
   where
     handlePasswordManagerError :: PasswordManagerError -> Handler a
     -- If there was a failure during password hashing, we return a 500 response
     handlePasswordManagerError FailedHashing = do
       log <& (Error, FailedHashing)
       throwError err500
-    -- In other cases, we return a 401 response
+
+    -- In other cases, return a 401 response
     handlePasswordManagerError (FailedJWTCreation e) = do
       log <& (Error, FailedJWTCreation e)
       throwError err401
-
--- |
--- Creates all the services needed by the application, creating a different contexts for the logger of each service
-appServices :: Connection -> JWK -> AppServices
-appServices connection key =
-  let
-    passwordManager' = encryptedPasswordManager (provideContext "PasswordManager" messageLogger) $ defaultJWTSettings key
-    dbUserRepository = postgresUserRepository connection
-  in  AppServices
-    { jwtSettings       = defaultJWTSettings key
-    , passwordManager   = passwordManager'
-    , contentRepository = connectedContentRepository (provideContext "ContentRepository" messageLogger) (postgresContentRepository connection)
-    , userRepository    = connectedUserRepository (provideContext "UserRepository" messageLogger) dbUserRepository
-    , authenticateUser  = connectedAuthenticateUser (provideContext "AuthenticateUser" messageLogger) dbUserRepository passwordManager'
-    }

--- a/src/Api/AppServices.hs
+++ b/src/Api/AppServices.hs
@@ -5,7 +5,7 @@
 
 module Api.AppServices
   ( AppServices (..),
-    appServices,
+    start,
     connectedContentRepository,
     connectedUserRepository,
     connectedAuthenticateUser,
@@ -56,8 +56,8 @@ data AppServices = AppServices
 type Log = SeverityLogger Handler
 
 -- Creates all the services needed by the application, creating a different contexts for the logger of each service
-appServices :: DB.Handle -> JWK -> AppServices
-appServices dbHandle key =
+start :: DB.Handle -> JWK -> AppServices
+start dbHandle key =
   let logContext name = provideContext name messageLogger
       passwordManager' = encryptedPasswordManager (logContext "PasswordManager") $ defaultJWTSettings key
       dbUserRepository = postgresUserRepository dbHandle

--- a/src/Api/Application.hs
+++ b/src/Api/Application.hs
@@ -6,41 +6,28 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Api.Application where
+module Api.Application (API, ApplicationAPI(..), app) where
 
 import Api.AppServices (AppServices(..))
 import Api.Authentication (AuthenticationAPI, authenticationServer)
 import Api.Docs (DocsAPI, docsServer)
 import Api.Healthcheck (HealthcheckAPI, healthcheckServer)
 import Api.Tagger (TaggerAPI, taggerServer)
+import Data.Proxy (Proxy(..))
+import GHC.Generics (Generic)
+import Network.Wai (Application)
+import Servant (Handler, serveWithContext, Context ((:.), EmptyContext), err401)
+import Servant.API (NamedRoutes, type (:>))
+import Servant.API.Generic ((:-))
+import Servant.Auth (Auth, JWT)
+import Servant.Auth.Server (defaultCookieSettings, AuthResult (Authenticated), ThrowAll (throwAll))
+import Servant.Server.Generic (AsServer)
 import Tagger.ContentRepository (ContentRepository)
 import Tagger.Id (Id)
 import Tagger.User (User)
 
--- base
-import Data.Proxy (Proxy(..))
-import GHC.Generics (Generic)
-
--- servant
-import Servant.API (NamedRoutes, type (:>))
-import Servant.API.Generic ((:-))
-
--- servant-auth
-import Servant.Auth (Auth, JWT)
-
--- servant-auth-server
-import Servant.Auth.Server (defaultCookieSettings, AuthResult (Authenticated), ThrowAll (throwAll))
-
--- servant-server
-import Servant (Handler, serveWithContext, Context ((:.), EmptyContext), err401)
-import Servant.Server.Generic (AsServer)
-
--- wai
-import Network.Wai (Application)
-
 type API = NamedRoutes ApplicationAPI
 
--- |
 -- Collects all the API groups exposed by the application
 data ApplicationAPI mode = ApplicationAPI
   { tagger         :: mode :- Auth '[JWT] (Id User) :> NamedRoutes TaggerAPI
@@ -50,15 +37,6 @@ data ApplicationAPI mode = ApplicationAPI
   }
   deriving stock Generic
 
--- |
--- For the endpoints which actually require authentication, checks whether the request provides a valid authentication token.
--- Otherwise it returns a 401 response
-authenticatedTaggerServer :: ContentRepository Handler -> AuthResult (Id User) -> TaggerAPI AsServer
-authenticatedTaggerServer contentRepository = \case
-  (Authenticated userId) -> taggerServer userId contentRepository
-  _                      -> throwAll err401
-
--- |
 -- Setup all the application server, providing the services needed by the various endpoints
 server :: AppServices -> ApplicationAPI AsServer
 server AppServices{passwordManager, contentRepository, userRepository, authenticateUser} = ApplicationAPI
@@ -67,6 +45,13 @@ server AppServices{passwordManager, contentRepository, userRepository, authentic
   , healthcheck    = healthcheckServer
   , authentication = authenticationServer passwordManager authenticateUser userRepository
   }
+
+-- For the endpoints which actually require authentication, checks whether the request provides a valid authentication token.
+-- Otherwise it returns a 401 response
+authenticatedTaggerServer :: ContentRepository Handler -> AuthResult (Id User) -> TaggerAPI AsServer
+authenticatedTaggerServer contentRepository = \case
+  (Authenticated userId) -> taggerServer userId contentRepository
+  _                      -> throwAll err401
 
 app :: AppServices -> Application
 app appServices = serveWithContext

--- a/src/Api/Config.hs
+++ b/src/Api/Config.hs
@@ -36,7 +36,6 @@ newtype User = User {getUser :: Text}
 
 newtype Password = Password {getPassword :: Text}
 
--- |
 -- Compute the connection string given a 'DatabaseConfig'
 connectionString :: DatabaseConfig -> ByteString
 connectionString DatabaseConfig{host, port, dbname, user, password} = pack

--- a/src/CLIOptions.hs
+++ b/src/CLIOptions.hs
@@ -1,15 +1,18 @@
-module InputOptions where
+module CLIOptions (CLIOptions(..), parse) where
 
--- optparse-applicative
-import Options.Applicative (Parser, strOption, long, metavar, help, showDefault, value)
+import Options.Applicative (Parser, strOption, long, metavar, help, showDefault, value, (<**>), execParser, helper, info, fullDesc)
 
-data InputOptions = InputOptions
+data CLIOptions = CLIOptions
   { configPath :: FilePath
   , jwkPath    :: FilePath
   }
 
-inputOptionsParser :: Parser InputOptions
-inputOptionsParser = InputOptions
+parse :: IO CLIOptions
+parse =
+  execParser $ info (inputOptionsParser <**> helper) fullDesc
+
+inputOptionsParser :: Parser CLIOptions
+inputOptionsParser = CLIOptions
   <$> strOption
     (  long "config"
     <> metavar "CONFIG"

--- a/src/Infrastructure/Authentication/AuthenticateUser.hs
+++ b/src/Infrastructure/Authentication/AuthenticateUser.hs
@@ -23,8 +23,8 @@ newtype AuthenticateUser m = AuthenticateUser {runAuthenticateUser :: Credential
 
 -- |
 -- Given a natural transformation between a context 'm' and a context 'n', it allows to change the context where 'AuthenticateUser' is operating
-hoistAuthenticateUser :: (forall a. m a -> n a) -> AuthenticateUser m -> AuthenticateUser n
-hoistAuthenticateUser f (AuthenticateUser auth) = AuthenticateUser $ f . auth
+hoist :: (forall a. m a -> n a) -> AuthenticateUser m -> AuthenticateUser n
+hoist f (AuthenticateUser auth) = AuthenticateUser $ f . auth
 
 -- |
 -- How 'authenticateUser' can actually fail

--- a/src/Infrastructure/Authentication/PasswordManager.hs
+++ b/src/Infrastructure/Authentication/PasswordManager.hs
@@ -36,8 +36,8 @@ data PasswordManager m = PasswordManager
 
 -- |
 -- Given a natural transformation between a context 'm' and a context 'n', it allows to change the context where 'PasswordManager' is operating
-hoistPasswordManager :: (forall a. m a -> n a) -> PasswordManager m -> PasswordManager n
-hoistPasswordManager f PasswordManager{generatePassword, generateToken, validatePassword} =
+hoist :: (forall a. m a -> n a) -> PasswordManager m -> PasswordManager n
+hoist f PasswordManager{generatePassword, generateToken, validatePassword} =
   PasswordManager (f . generatePassword) (f . generateToken) validatePassword
 
 -- |

--- a/src/Infrastructure/Persistence/PostgresContentRepository.hs
+++ b/src/Infrastructure/Persistence/PostgresContentRepository.hs
@@ -2,55 +2,45 @@
 
 module Infrastructure.Persistence.PostgresContentRepository where
 
-import Infrastructure.Persistence.Serializer (unserializeContent, serializeContent)
-import qualified Infrastructure.Persistence.Queries as DB (selectUserContents, addContentWithTags)
+import Control.Monad (forM)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Except (ExceptT (ExceptT))
+import Data.Tuple.Extra (uncurry3)
+import Data.UUID.V4 (nextRandom)
+import Hasql.Session (QueryError)
+import qualified Infrastructure.Persistence.Queries as DB (addContentWithTags, selectUserContents)
+import Infrastructure.Persistence.Serializer (serializeContent, unserializeContent)
 import Tagger.Content (Content, hasAllTags)
-import Tagger.ContentRepository (ContentRepository(..))
-import Tagger.Id (Id(Id))
-import Tagger.Owned (Owned(content))
+import Tagger.ContentRepository (ContentRepository (..))
+import qualified Tagger.Database as DB
+import Tagger.Id (Id (Id))
+import Tagger.Owned (Owned (content))
 import Tagger.Tag (Tag)
 import Tagger.User (User)
 
--- base
-import Control.Monad (forM)
-import Control.Monad.IO.Class (liftIO)
-
--- extra
-import Data.Tuple.Extra (uncurry3)
-
--- hasql
-import Hasql.Connection (Connection)
-import Hasql.Session (run, QueryError)
-
--- transformers
-import Control.Monad.Trans.Except (ExceptT (ExceptT))
-
--- uuid
-import Data.UUID.V4 (nextRandom)
-
--- |
 -- A 'ContentRepository' based on PostgreSQL
-postgresContentRepository :: Connection -> ContentRepository (ExceptT QueryError IO)
-postgresContentRepository connection = ContentRepository
-  { selectUserContentsByTags = postgresSelectUserContentsByTags connection
-  , addContentWithTags       = postgresAddContentWithTags connection
-  }
+postgresContentRepository :: DB.Handle -> ContentRepository (ExceptT QueryError IO)
+postgresContentRepository handle =
+  ContentRepository
+    { selectUserContentsByTags = postgresSelectUserContentsByTags handle,
+      addContentWithTags = postgresAddContentWithTags handle
+    }
 
-postgresSelectUserContentsByTags :: Connection -> Id User -> [Tag] -> ExceptT QueryError IO [Owned (Content Tag)]
-postgresSelectUserContentsByTags connection userId tags = do
+postgresSelectUserContentsByTags :: DB.Handle -> Id User -> [Tag] -> ExceptT QueryError IO [Owned (Content Tag)]
+postgresSelectUserContentsByTags handle userId tags = do
   -- Retrieve the user's contents data from the database
-  userDBContents <- ExceptT $ run (DB.selectUserContents userId) connection
+  userDBContents <- ExceptT $ DB.runQuery handle (DB.selectUserContents userId)
   -- Convert the contents data into their domain representation
   let userContents = uncurry3 unserializeContent <$> userDBContents
   -- Filter only the contents indexed by the provided tags
   pure $ filter (hasAllTags tags . content) userContents
 
-postgresAddContentWithTags :: Connection -> Id User -> Content Tag -> ExceptT QueryError IO (Id (Content Tag))
-postgresAddContentWithTags connection userId content' = do
+postgresAddContentWithTags :: DB.Handle -> Id User -> Content Tag -> ExceptT QueryError IO (Id (Content Tag))
+postgresAddContentWithTags handle userId content' = do
   -- Generate a UUID for the content
-  contentUUID          <- liftIO nextRandom
+  contentUUID <- liftIO nextRandom
   -- Generate and associate a UUID to every tag
-  contentWithTagsUUIDs <- liftIO $ forM content' (\tag -> (, tag) . Id <$> nextRandom)
+  contentWithTagsUUIDs <- liftIO $ forM content' (\tag -> (,tag) . Id <$> nextRandom)
   -- Run a transaction to add the content and its tags to the database
-  ExceptT $ run (uncurry DB.addContentWithTags $ serializeContent (Id contentUUID) userId contentWithTagsUUIDs) connection
+  ExceptT $ DB.runQuery handle (uncurry DB.addContentWithTags $ serializeContent (Id contentUUID) userId contentWithTagsUUIDs)
   pure $ Id contentUUID

--- a/src/Infrastructure/Persistence/PostgresUserRepository.hs
+++ b/src/Infrastructure/Persistence/PostgresUserRepository.hs
@@ -2,65 +2,53 @@
 
 module Infrastructure.Persistence.PostgresUserRepository where
 
-import qualified Infrastructure.Persistence.Queries as Query (addUser, selectUserByName)
-import Infrastructure.Persistence.Serializer (serializeUser, unserializeUser)
-import Infrastructure.Persistence.Schema (litUser, userId)
-import Tagger.EncryptedPassword (EncryptedPassword)
-import Tagger.Id (Id(Id))
-import Tagger.User (User(User))
-import Tagger.UserRepository (SelectUserError, UserRepository(..))
-
--- base
 import Control.Arrow ((&&&))
 import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Except (ExceptT (ExceptT), withExceptT)
 import Data.Bifunctor (second)
-
--- bytestring
 import Data.ByteString (isInfixOf)
-
--- hasql
-import Hasql.Connection (Connection)
-import Hasql.Session (QueryError (QueryError), run, CommandError (ResultError), ResultError (ServerError))
-
--- text
 import Data.Text (Text)
-
--- transformers
-import Control.Monad.Trans.Except (ExceptT(ExceptT), withExceptT)
-
--- uuid
 import Data.UUID.V4 (nextRandom)
+import Hasql.Session (CommandError (ResultError), QueryError (QueryError), ResultError (ServerError))
+import qualified Infrastructure.Persistence.Queries as Query (addUser, selectUserByName)
+import Infrastructure.Persistence.Schema (litUser, userId)
+import Infrastructure.Persistence.Serializer (serializeUser, unserializeUser)
+import qualified Tagger.Database as DB
+import Tagger.EncryptedPassword (EncryptedPassword)
+import Tagger.Id (Id (Id))
+import Tagger.User (User (User))
+import Tagger.UserRepository (SelectUserError, UserRepository (..))
 
 -- We want to distinguish the `QueryError` coming from the violation of the "users_name_key" unique constraints
 data UserRepositoryError
   = DuplicateUserName QueryError
   | OtherError QueryError
-  deriving Show
+  deriving (Show)
 
 liftAddUserError :: QueryError -> UserRepositoryError
 liftAddUserError queryError@(QueryError _ _ (ResultError (ServerError "23505" message _ _)))
   | "users_name_key" `isInfixOf` message = DuplicateUserName queryError
-liftAddUserError queryError              = OtherError queryError
+liftAddUserError queryError = OtherError queryError
 
--- |
 -- A 'UserRepository' based on PostgreSQL
-postgresUserRepository :: Connection -> UserRepository (ExceptT UserRepositoryError IO)
-postgresUserRepository connection = UserRepository
-  { getUserByName = postgresGetUserByName connection
-  , addUser       = postgresAddUser connection
-  }
+postgresUserRepository :: DB.Handle -> UserRepository (ExceptT UserRepositoryError IO)
+postgresUserRepository handle =
+  UserRepository
+    { getUserByName = postgresGetUserByName handle,
+      addUser = postgresAddUser handle
+    }
 
-postgresGetUserByName :: Connection -> Text -> ExceptT UserRepositoryError IO (Either SelectUserError (Id User, User))
-postgresGetUserByName connection name = withExceptT OtherError . ExceptT $ do
+postgresGetUserByName :: DB.Handle -> Text -> ExceptT UserRepositoryError IO (Either SelectUserError (Id User, User))
+postgresGetUserByName handle name = withExceptT OtherError . ExceptT $ do
   -- Try to retrieve the user with the provided name from the database
-  eitherUser <- run (Query.selectUserByName name) connection
+  eitherUser <- DB.runQuery handle (Query.selectUserByName name)
   -- Adjust the happy path format
   pure $ second (userId &&& unserializeUser) <$> eitherUser
 
-postgresAddUser :: Connection -> Text -> EncryptedPassword -> ExceptT UserRepositoryError IO (Id User)
-postgresAddUser connection name password = do
+postgresAddUser :: DB.Handle -> Text -> EncryptedPassword -> ExceptT UserRepositoryError IO (Id User)
+postgresAddUser handle name password = do
   -- Generate the UUID for the user
   userId' <- liftIO nextRandom
   -- Actually add the user to the database, differentiating the `UserRepositoryError` cases
-  withExceptT liftAddUserError . ExceptT $ run (Query.addUser . litUser $ serializeUser (Id userId') (User name password)) connection
+  withExceptT liftAddUserError . ExceptT $ DB.runQuery handle (Query.addUser . litUser $ serializeUser (Id userId') (User name password))
   pure $ Id userId'

--- a/src/Tagger/ContentRepository.hs
+++ b/src/Tagger/ContentRepository.hs
@@ -9,7 +9,6 @@ import Tagger.Tag (Tag)
 import Tagger.Owned (Owned)
 import Tagger.User (User)
 
--- |
 -- A 'ContentRepository' represents a collection of 'Content's.
 -- It is indexed by a context 'm' which wraps the results.
 data ContentRepository m = ContentRepository
@@ -17,8 +16,7 @@ data ContentRepository m = ContentRepository
   , addContentWithTags       :: Id User -> Content Tag -> m (Id (Content Tag)) -- ^ adds a 'Content' indexed by some 'Tag's for a 'User' identified by a given 'Id'
   }
 
--- |
 -- Given a natural transformation between a context 'm' and a context 'n', it allows to change the context where 'ContentRepository' is operating
-hoistContentRepository :: (forall a. m a -> n a) -> ContentRepository m -> ContentRepository n
-hoistContentRepository f ContentRepository{selectUserContentsByTags, addContentWithTags} =
+hoist :: (forall a. m a -> n a) -> ContentRepository m -> ContentRepository n
+hoist f ContentRepository{selectUserContentsByTags, addContentWithTags} =
   ContentRepository ((f .) . selectUserContentsByTags) ((f .) . addContentWithTags)

--- a/src/Tagger/Database.hs
+++ b/src/Tagger/Database.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Tagger.Database
+  ( Config (..),
+    Handle,
+    parseConfig,
+    new,
+    close,
+    withHandle,
+    runQuery,
+  )
+where
+
+import Api.Config (dbConfig)
+import qualified Api.Config as AppConfig
+import Data.ByteString.Char8 (ByteString, unpack)
+import Data.Maybe (fromMaybe)
+import Hasql.Connection (Connection, acquire)
+import Hasql.Session (QueryError, Session, run)
+
+newtype Config = Config
+  { connectionString :: ByteString
+  }
+
+newtype Handle = Handle
+  { dbConnection :: Connection
+  }
+
+new :: Config -> IO Handle
+new config = do
+  eConn <- acquire . connectionString $ config
+  either
+    (fail . unpack . fromMaybe "unable to connect to the database")
+    (pure . Handle)
+    eConn
+
+parseConfig :: AppConfig.Config -> Config
+parseConfig =
+  Config . (AppConfig.connectionString . dbConfig)
+
+close :: Handle -> IO ()
+close = undefined
+
+withHandle :: Config -> (Handle -> IO a) -> IO a
+withHandle = undefined
+
+runQuery :: Handle -> Session a -> IO (Either QueryError a)
+runQuery handle query =
+  run query (dbConnection handle)

--- a/src/Tagger/Database.hs
+++ b/src/Tagger/Database.hs
@@ -6,7 +6,6 @@ module Tagger.Database
     parseConfig,
     new,
     close,
-    withHandle,
     runQuery,
   )
 where
@@ -39,10 +38,7 @@ parseConfig =
   Config . (AppConfig.connectionString . dbConfig)
 
 close :: Handle -> IO ()
-close = undefined
-
-withHandle :: Config -> (Handle -> IO a) -> IO a
-withHandle = undefined
+close _ = pure ()
 
 runQuery :: Handle -> Session a -> IO (Either QueryError a)
 runQuery handle query =

--- a/src/Tagger/JSONWebKey.hs
+++ b/src/Tagger/JSONWebKey.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Tagger.JWK (setup, JWK) where
+module Tagger.JSONWebKey (setup, JWK) where
 
 import CLIOptions (CLIOptions (jwkPath))
 import Control.Exception (catch)
@@ -10,11 +10,8 @@ import Servant.Auth.Server (fromSecret, generateSecret, readKey)
 import Prelude hiding (writeFile)
 
 setup :: CLIOptions -> IO JWK
-setup =
-  jwtKey . jwkPath
-
-jwtKey :: FilePath -> IO JWK
-jwtKey path = do
+setup config = do
+  let path = jwkPath config
   -- try to retrieve the JWK from file
   catch (readKey path) $ \(_ :: IOError) -> do
     -- if the file does not exist or does not contain a valid key, we generate one

--- a/src/Tagger/JWK.hs
+++ b/src/Tagger/JWK.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Tagger.JWK (setup, JWK) where
+
+import CLIOptions (CLIOptions (jwkPath))
+import Control.Exception (catch)
+import Crypto.JOSE.JWK (JWK)
+import Data.ByteString.Char8 (writeFile)
+import Servant.Auth.Server (fromSecret, generateSecret, readKey)
+import Prelude hiding (writeFile)
+
+setup :: CLIOptions -> IO JWK
+setup =
+  jwtKey . jwkPath
+
+jwtKey :: FilePath -> IO JWK
+jwtKey path = do
+  -- try to retrieve the JWK from file
+  catch (readKey path) $ \(_ :: IOError) -> do
+    -- if the file does not exist or does not contain a valid key, we generate one
+    key <- generateSecret
+    -- and we store it
+    writeFile path key
+    pure $ fromSecret key

--- a/src/Tagger/UserRepository.hs
+++ b/src/Tagger/UserRepository.hs
@@ -6,11 +6,8 @@ module Tagger.UserRepository where
 import Tagger.EncryptedPassword (EncryptedPassword)
 import Tagger.Id (Id)
 import Tagger.User (User)
-
--- text
 import Data.Text (Text)
 
--- |
 -- When we 'getUserByName' we expect only one 'User' in return.
 -- 'SelectUserError' describes how this can fail
 data SelectUserError
@@ -18,7 +15,6 @@ data SelectUserError
   | MoreThanOneUser -- ^ we are expecting one user, but actually more than one user is found
   deriving Show
 
--- |
 -- A 'UserRespository' represents a collection of 'User's.
 -- It is indexed by a context 'm' which wraps the results.
 data UserRepository m = UserRepository
@@ -26,7 +22,7 @@ data UserRepository m = UserRepository
   , addUser       :: Text -> EncryptedPassword -> m (Id User)           -- ^ tries to add a user with the provided name and password
   }
 
--- |
--- Given a natural transformation between a context 'm' and a context 'n', it allows to change the context where 'UserRepository' is operating
-hoistUserRepository :: (forall a. m a -> n a) -> UserRepository m -> UserRepository n
-hoistUserRepository f UserRepository{getUserByName, addUser} = UserRepository (f . getUserByName) ((f .) . addUser)
+-- Given a natural transformation between a context 'm' and a context 'n',
+-- it allows to change the context where 'UserRepository' is operating
+hoist :: (forall a. m a -> n a) -> UserRepository m -> UserRepository n
+hoist f UserRepository{getUserByName, addUser} = UserRepository (f . getUserByName) ((f .) . addUser)


### PR DESCRIPTION
Although a large pull request, the code is functionally unchanged. Most modifications are either cosmetic or aimed at improving design.

- Various readability refactors
  - Prefer aptly named functions that encapsulate functionality over comments
  - Limit exposure of lower-level types/libraries by improving modularization
  - Remove package names from import lists
- Switch implementation of the database module to the [Handle Pattern](https://github.com/tweag/meta/blob/master/handbook/eng/essential-reading.md#technology-specific-reading)
- ~Format Haskell code with `ormolu`~
- ~Format Elm code with `elm-format`~
- ~Provide scripts for formatting and linting the entire codebase (`bin/format`, `bin/lint`)~
> The last three points will be done in a separate pull request.