### PR TITLE
Refactor Logger module

### DIFF
--- a/app/Dependencies.hs
+++ b/app/Dependencies.hs
@@ -1,0 +1,23 @@
+module Dependencies (withDeps, Deps (..)) where
+
+import qualified Api.Config as Config
+import qualified Infrastructure.Database as DB
+import qualified Infrastructure.Logging.Logger as Logger
+import qualified Infrastructure.SystemTime as SystemTime
+
+-- |
+-- Aggregates all effects needed by the app
+data Deps = Deps
+  { systemTimeHandler :: SystemTime.Handle,
+    loggerHandle :: Logger.Handle,
+    dbHandle :: DB.Handle
+  }
+
+-- |
+-- Starts dependencies and calls a given effectful function with them
+withDeps :: Config.Config -> (Deps  -> IO a) -> IO a
+withDeps appConfig f = do
+  SystemTime.withHandle $ \systemTime ->
+    Logger.withHandle systemTime $ \logger ->
+      DB.withHandle appConfig $ \db -> do
+        f $ Deps systemTime logger db

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,6 +7,8 @@ import qualified Api.Config as Config
 import CLIOptions (CLIOptions (configPath))
 import qualified CLIOptions
 import qualified Infrastructure.Database as DB
+import qualified Infrastructure.Logging.Logger as Logger
+import qualified Infrastructure.SystemTime as SystemTime
 import qualified Middleware
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Tagger.JSONWebKey as JWK
@@ -16,7 +18,8 @@ main = do
   options <- CLIOptions.parse
   appConfig <- Config.load $ configPath options
   key <- JWK.setup options
-  DB.withHandle appConfig (\dbHandle -> do
+  Deps.withDeps config (\Deps { dbHandle, loggerHandle }-> do
+    let services = appServices dbHandle loggerHandle key
     let (Port port) = apiPort . Config.api $ appConfig
         services = AppServices.start dbHandle key
         application = Middleware.apply (app services)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,14 +1,17 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Main where
 
-import qualified Api.AppServices as AppServices
+import Api.AppServices as AppServices
 import Api.Application (app)
 import Api.Config (Port (..), apiPort)
 import qualified Api.Config as Config
 import CLIOptions (CLIOptions (configPath))
 import qualified CLIOptions
-import qualified Infrastructure.Database as DB
-import qualified Infrastructure.Logging.Logger as Logger
-import qualified Infrastructure.SystemTime as SystemTime
+import Dependencies (Deps (..))
+import qualified Dependencies as Deps
 import qualified Middleware
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Tagger.JSONWebKey as JWK
@@ -18,10 +21,12 @@ main = do
   options <- CLIOptions.parse
   appConfig <- Config.load $ configPath options
   key <- JWK.setup options
-  Deps.withDeps config (\Deps { dbHandle, loggerHandle }-> do
-    let services = appServices dbHandle loggerHandle key
-    let (Port port) = apiPort . Config.api $ appConfig
-        services = AppServices.start dbHandle key
-        application = Middleware.apply (app services)
+  Deps.withDeps
+    appConfig
+    ( \Deps {dbHandle, loggerHandle} -> do
+        let (Port port) = apiPort . Config.api $ appConfig
+            services = AppServices.start dbHandle loggerHandle key
+            application = Middleware.apply (app services)
 
-    Warp.run port application)
+        Warp.run port application
+    )

--- a/spec/TestServices.hs
+++ b/spec/TestServices.hs
@@ -5,6 +5,8 @@ module TestServices where
 import Api.AppServices (AppServices(..), connectedAuthenticateUser, connectedContentRepository, connectedUserRepository, encryptedPasswordManager)
 import InMemoryContentRepository (inMemoryContentRepository)
 import InMemoryUserRepository (inMemoryUserRepository)
+import Infrastructure.Logging.Logger as Logger
+import Infrastructure.SystemTime as SystemTime
 
 -- base
 import GHC.Conc (newTVarIO)
@@ -17,13 +19,15 @@ testServices = do
   key         <- generateKey
   userMap     <- newTVarIO mempty
   contentsMap <- newTVarIO mempty
-  let passwordManager'   = encryptedPasswordManager mempty $ defaultJWTSettings key
-  let userRepository'    = inMemoryUserRepository userMap
-  let contentsRepository = inMemoryContentRepository contentsMap
-  pure $ AppServices
-    { jwtSettings       = defaultJWTSettings key
-    , passwordManager   = passwordManager'
-    , contentRepository = connectedContentRepository mempty contentsRepository
-    , userRepository    = connectedUserRepository mempty userRepository'
-    , authenticateUser  = connectedAuthenticateUser mempty userRepository' passwordManager'
-    }
+  SystemTime.withHandle $ \timeHandle ->
+    Logger.withHandle timeHandle $ \loggerHandle -> do
+      let passwordManager'   = encryptedPasswordManager loggerHandle $ defaultJWTSettings key
+      let userRepository'    = inMemoryUserRepository userMap
+      let contentsRepository = inMemoryContentRepository contentsMap
+      pure $ AppServices
+        { jwtSettings       = defaultJWTSettings key
+        , passwordManager   = passwordManager'
+        , contentRepository = connectedContentRepository loggerHandle contentsRepository
+        , userRepository    = connectedUserRepository loggerHandle userRepository'
+        , authenticateUser  = connectedAuthenticateUser loggerHandle userRepository' passwordManager'
+        }

--- a/src/Api/AppServices.hs
+++ b/src/Api/AppServices.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TupleSections #-}
 
 module Api.AppServices where
 
 import qualified Infrastructure.Authentication.AuthenticateUser as Auth (AuthenticateUser(AuthenticateUser), AuthenticationError(AuthenticationQueryError), authenticateUser, hoist)
 import qualified Infrastructure.Authentication.PasswordManager as PasswordManager
 import Infrastructure.Authentication.PasswordManager (PasswordManager, PasswordManagerError(..), bcryptPasswordManager)
-import Infrastructure.Logging.Logger (messageLogger, provideContext)
+import qualified Infrastructure.Logging.Logger as Logger
+import Infrastructure.Logging.Logger (withContext, logError, logWarning)
 import Infrastructure.Persistence.PostgresContentRepository (postgresContentRepository)
 import Infrastructure.Persistence.PostgresUserRepository (postgresUserRepository, UserRepositoryError (DuplicateUserName))
 import qualified Tagger.ContentRepository as ContentRepository
@@ -19,9 +19,6 @@ import Tagger.UserRepository (UserRepository)
 import Control.Monad ((<=<))
 import Control.Monad.IO.Class (liftIO)
 import Prelude hiding (log)
-
--- co-log-core
-import Colog.Core ((<&), LogAction, Severity(..))
 
 -- hasql
 import Hasql.Session (QueryError)
@@ -54,38 +51,34 @@ data AppServices = AppServices
   }
 
 -- |
--- 'LogAction' which accepts any 'Show'able data type and a 'Severity'
-type SeverityLogger = forall a. Show a => LogAction Handler (Severity, a)
-
--- |
 -- Lifts a computation from 'ExceptT e IO' to 'Handler a' using the provided 'handleError' function
 eitherTToHandler :: (e -> Handler a) -> ExceptT e IO a -> Handler a
 eitherTToHandler handleError = either handleError pure <=< liftIO . runExceptT
 
 -- |
 -- Lifts a 'ContentRepository' fo the 'Handler' monad, handling all errors by logging them and returning a 500 response
-connectedContentRepository :: SeverityLogger -> ContentRepository (ExceptT QueryError IO) -> ContentRepository Handler
-connectedContentRepository log = ContentRepository.hoist (eitherTToHandler $ (>> throwError err500) . (log <&) . (Error ,))
+connectedContentRepository :: Logger.Handle -> ContentRepository (ExceptT QueryError IO) -> ContentRepository Handler
+connectedContentRepository logHandle = ContentRepository.hoist (eitherTToHandler $ (>> throwError err500) . logError logHandle . show)
 
 -- |
 -- Lifts a 'UserRepository' fo the 'Handler' monad, handling all errors by logging them and returning a 500 response
-connectedUserRepository :: SeverityLogger -> UserRepository (ExceptT UserRepositoryError IO) -> UserRepository Handler
-connectedUserRepository log = UserRepository.hoist $ eitherTToHandler handleUserRepositoryError-- (eitherTToHandler $ (>> throwError err500) . (log <&) . (Error ,))
+connectedUserRepository :: Logger.Handle -> UserRepository (ExceptT UserRepositoryError IO) -> UserRepository Handler
+connectedUserRepository logHandle = UserRepository.hoist $ eitherTToHandler handleUserRepositoryError
   where
     handleUserRepositoryError :: UserRepositoryError -> Handler a
     -- If the database error concerns a duplicate user, we return a 403 response
     handleUserRepositoryError (DuplicateUserName e) = do
-      log <& (Warning, DuplicateUserName e)
+      logWarning logHandle $ show (DuplicateUserName e)
       throwError err403
     -- Otherwise, we return a 500 response
     handleUserRepositoryError e                     = do
-      log <& (Error, e)
+      logError logHandle (show e)
       throwError err500
 
 -- |
 -- Creates an 'AuthenticateUser' service injecting its dependencies and handling errors
-connectedAuthenticateUser :: SeverityLogger -> UserRepository (ExceptT UserRepositoryError IO) -> PasswordManager Handler -> Auth.AuthenticateUser Handler
-connectedAuthenticateUser log userRepository' passwordManager'
+connectedAuthenticateUser :: Logger.Handle -> UserRepository (ExceptT UserRepositoryError IO) -> PasswordManager Handler -> Auth.AuthenticateUser Handler
+connectedAuthenticateUser logHandle userRepository' passwordManager'
   = Auth.hoist (eitherTToHandler handleAuthenticationError)
   . Auth.AuthenticateUser
   $ Auth.authenticateUser userRepository' passwordManager'
@@ -93,39 +86,39 @@ connectedAuthenticateUser log userRepository' passwordManager'
       handleAuthenticationError :: Auth.AuthenticationError -> Handler a
       -- If there was an error at the database level, we return a 500 response
       handleAuthenticationError (Auth.AuthenticationQueryError e) = do
-        log <& (Error, Auth.AuthenticationQueryError e)
+        logError logHandle $ show (Auth.AuthenticationQueryError e)
         throwError err500
         -- In other cases, there was an authentication error and we return a 401 response
       handleAuthenticationError e = do
-        log <& (Warning, e)
+        logWarning logHandle (show e)
         throwError err401
 
 -- |
 -- Creates a 'PasswordManager' service injecting its dependencies and handling errors
-encryptedPasswordManager :: SeverityLogger -> JWTSettings -> PasswordManager Handler
-encryptedPasswordManager log = PasswordManager.hoist (eitherTToHandler handlePasswordManagerError) . bcryptPasswordManager
+encryptedPasswordManager :: Logger.Handle -> JWTSettings -> PasswordManager Handler
+encryptedPasswordManager logHandle = PasswordManager.hoist (eitherTToHandler handlePasswordManagerError) . bcryptPasswordManager
   where
     handlePasswordManagerError :: PasswordManagerError -> Handler a
     -- If there was a failure during password hashing, we return a 500 response
     handlePasswordManagerError FailedHashing = do
-      log <& (Error, FailedHashing)
+      logError logHandle $ show FailedHashing
       throwError err500
     -- In other cases, we return a 401 response
     handlePasswordManagerError (FailedJWTCreation e) = do
-      log <& (Error, FailedJWTCreation e)
+      logError logHandle $ show (FailedJWTCreation e)
       throwError err401
 
 -- |
--- Creates all the services needed by the application, creating a different contexts for the logger of each service
-start :: DB.Handle -> JWK -> AppServices
-start handle key =
+start :: DB.Handle -> Logger.Handle -> JWK -> AppServices
+start dbHandle logHandle key =
   let
-    passwordManager' = encryptedPasswordManager (provideContext "PasswordManager" messageLogger) $ defaultJWTSettings key
-    dbUserRepository = postgresUserRepository handle
+    logContext = flip withContext logHandle
+    passwordManager' = encryptedPasswordManager (withContext "PasswordManager" logHandle) $ defaultJWTSettings key
+    dbUserRepository = postgresUserRepository dbHandle
   in  AppServices
     { jwtSettings       = defaultJWTSettings key
     , passwordManager   = passwordManager'
-    , contentRepository = connectedContentRepository (provideContext "ContentRepository" messageLogger) (postgresContentRepository handle)
-    , userRepository    = connectedUserRepository (provideContext "UserRepository" messageLogger) dbUserRepository
-    , authenticateUser  = connectedAuthenticateUser (provideContext "AuthenticateUser" messageLogger) dbUserRepository passwordManager'
+    , contentRepository = connectedContentRepository (logContext "ContentRepository") (postgresContentRepository dbHandle)
+    , userRepository    = connectedUserRepository (logContext "UserRepository") dbUserRepository
+    , authenticateUser  = connectedAuthenticateUser (logContext "AuthenticateUser") dbUserRepository passwordManager'
     }

--- a/src/Infrastructure/Logging/Logger.hs
+++ b/src/Infrastructure/Logging/Logger.hs
@@ -1,55 +1,121 @@
-{-# LANGUAGE RankNTypes #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
-module Infrastructure.Logging.Logger where
+module Infrastructure.Logging.Logger
+  ( Handle,
+    withHandle,
+    withContext,
+    logError,
+    logInfo,
+    logWarning,
+  )
+where
 
--- base
-import Control.Monad.IO.Class (MonadIO (liftIO))
+import Colog.Core (Severity (..), logStringStderr, logStringStdout, (<&))
+import Control.Exception (bracket)
+import Control.Monad (when)
+import Control.Monad.IO.Class (MonadIO)
+import Data.Text (Text)
+import Infrastructure.SystemTime (UTCTime)
+import qualified Infrastructure.SystemTime as SystemTime
+import Prelude hiding (log)
 
--- co-log-core
-import Colog.Core (LogAction, cmapM, logPrintStderr, (>$<))
-import Colog.Core.Severity (Severity)
-
--- text
-import Data.Text (Text, unpack)
-
--- time
-import Data.Time.Clock (UTCTime, getCurrentTime)
-
--- |
--- A 'Message' defines the format we want to user to log errors
-data Message a = Message
-  { context  :: Text     -- ^ the 'context' describes where the error happened
-  , severity :: Severity -- ^ the severity describes how serious the error is
-  , message  :: a        -- ^ the actual payload of the message
+newtype Config = Config
+  { logLevel :: Severity
   }
 
--- |
--- 'Timed' is used to add information about the time when an error happened
-data Timed a = Timed
-  { time  :: UTCTime
-  , value :: a
+data Handle = Handle
+  { systemTimeHandle :: SystemTime.Handle,
+    localContext :: Maybe Context,
+    minLevel :: Severity
   }
 
-formatTimedMessage :: Show a => Timed (Message a) -> String
-formatTimedMessage (Timed time' (Message context' severity' message'))
-  =  "[" <> show severity'  <> "] "
-  <> "[" <> show time'      <> "] "
-  <> "[" <> unpack context' <> "] "
-  <> show message'
+type Context = Text
 
 -- |
--- Allows us to provide just a 'Message' but actually log a 'Timed Message'
-untimedMessageLogger :: (MonadIO m) => LogAction m (Timed (Message a)) -> LogAction m (Message a)
-untimedMessageLogger = cmapM $ \message' -> do
-  currentTime <- liftIO getCurrentTime
-  pure $ Timed currentTime message'
+-- Uses dependencies to yield a handle
+withHandle :: SystemTime.Handle -> (Handle -> IO a) -> IO a
+withHandle timeHandle f = do
+  bracket
+    (new parseConfig timeHandle)
+    close
+    f
 
 -- |
--- A 'LogAction' which requires 'Message's and logs 'Timed Message's to standard error
-messageLogger :: (MonadIO m, Show a) => LogAction m (Message a)
-messageLogger = untimedMessageLogger $ formatTimedMessage >$< logPrintStderr
+-- Returns new handle that logs within a specific context.
+withContext :: Context -> Handle -> Handle
+withContext context handle = handle {localContext = Just context}
 
 -- |
--- Allows to add at a later time a context, so that we can log directly a message with its security level
-provideContext :: Text -> LogAction m (Message a) -> LogAction m (Severity, a)
-provideContext context' logger = uncurry (Message context') >$< logger
+-- Logs message with severity set to Error
+logError :: MonadIO m => Handle -> String -> m ()
+logError = log Error
+
+-- |
+-- Logs message with severity set to Info
+logInfo :: MonadIO m => Handle -> String -> m ()
+logInfo = log Info
+
+-- |
+-- Logs message with severity set to Warning
+logWarning :: MonadIO m => Handle -> String -> m ()
+logWarning = log Warning
+
+-- |
+-- Logs message with severity set to Debug
+logDebug :: MonadIO m => Handle -> String -> m ()
+logDebug = log Debug
+
+-- |
+-- Logs timestamped message with added severity and context
+-- information to appropriate file descriptor if severity meets
+-- minimum configured level
+log :: (MonadIO m) => Severity -> Handle -> String -> m ()
+log level handle msg = do
+  currentTime <- SystemTime.currentTime $ systemTimeHandle handle
+  let formattedLine = format currentTime level (localContext handle) msg
+  when (level >= minLevel handle) (logAction <& formattedLine)
+  where
+    logAction =
+      case level of
+        Error ->
+          logStringStderr
+        _ ->
+          logStringStdout
+
+-- |
+-- Creates new handle
+new :: Config -> SystemTime.Handle -> IO Handle
+new config timeHandle = do
+  pure $
+    Handle
+      { systemTimeHandle = timeHandle,
+        localContext = Nothing,
+        minLevel = logLevel config
+      }
+
+-- |
+-- Cleanup function
+close :: Handle -> IO ()
+close = const $ pure ()
+
+-- |
+-- Create Logger config
+parseConfig :: Config
+parseConfig = Config Info
+
+newtype Unquoted = Unquoted String
+
+instance Show Unquoted where
+  show (Unquoted str) = str
+
+-- |
+-- Formats in following format:
+-- [Severity] [2022-06-13 14:54:39.043078872 UTC] [Context] Log message
+-- or (without context):
+-- [Severity] [2022-06-13 14:54:39.043078872 UTC] Log message
+format :: UTCTime -> Severity -> Maybe Context -> String -> String
+format time severity ctx msg =
+  withBrackets severity <> withBrackets time <> maybe "" withBrackets ctx <> msg
+  where
+    withBrackets s =
+      "[" <> show s <> "] "

--- a/src/Infrastructure/SystemTime.hs
+++ b/src/Infrastructure/SystemTime.hs
@@ -1,0 +1,33 @@
+module Infrastructure.SystemTime
+  ( Handle,
+    withHandle,
+    currentTime,
+    UTCTime,
+  )
+where
+
+import Control.Exception (bracket)
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.Time.Clock (UTCTime, getCurrentTime)
+
+data Handle = Handle
+
+-- |
+-- Yields a handle
+withHandle :: (Handle -> IO a) -> IO a
+withHandle = bracket new close
+
+-- |
+-- Returns current time
+currentTime :: MonadIO m => Handle -> m UTCTime
+currentTime = const $ liftIO getCurrentTime
+
+-- |
+-- Creates new handle
+new :: MonadIO m => m Handle
+new = pure Handle
+
+-- |
+-- Cleanup function
+close :: MonadIO m => Handle -> m ()
+close = const $ pure ()


### PR DESCRIPTION
- Logger now implements Handle Pattern
- Implementation details are not exposed to application
- Dependency on system time is now explicit
  - Additional `Infrastructure.SystemTime` module also added and passed in when starting logger in `Main`
- Logging functions now accept only `String` for better transparency and control of how log messages look like (no extraneous quotation marks for strings anymore)
- Dependency setup was extracted from `Main` into `Dependencies`. I don't know if they should be in `app/` or `src/` but this is an easy fix if you think another way is better