### PR TITLE
Rework error handling as part of the monadic context

### DIFF
--- a/spec/InMemoryUserRepository.hs
+++ b/spec/InMemoryUserRepository.hs
@@ -9,29 +9,32 @@ import Data.Text.Encoding (encodeUtf8)
 import Data.UUID.V4 (nextRandom)
 import GHC.Conc (TVar, atomically, readTVar, writeTVar)
 import Hasql.Session (CommandError (ResultError), QueryError (QueryError), ResultError (ServerError))
-import Infrastructure.Persistence.PostgresUserRepository (UserRepositoryError (DuplicateUserName))
+import Infrastructure.Persistence.PostgresUserRepository (UserRepositoryError (..))
+import Infrastructure.Persistence.Queries (WrongNumberOfRows (..))
 import PostgreSQL.ErrorCodes (unique_violation)
 import Tagger.EncryptedPassword (EncryptedPassword)
 import Tagger.Id (Id (Id))
 import Tagger.User (User (..))
-import Tagger.UserRepository (SelectUserError (..), UserRepository (..))
+import Tagger.UserRepository (UserRepository (..))
 import Prelude hiding (filter)
 
-inMemoryUserRepository :: TVar (Map (Id User) User) -> UserRepository (ExceptT UserRepositoryError IO)
+type Ctx = ExceptT UserRepositoryError IO
+
+inMemoryUserRepository :: TVar (Map (Id User) User) -> UserRepository Ctx
 inMemoryUserRepository userMap =
   UserRepository
     { getUserByName = inMemoryGetUserByName userMap,
       addUser = inMemoryAddUser userMap
     }
 
-inMemoryGetUserByName :: TVar (Map (Id User) User) -> Text -> ExceptT UserRepositoryError IO (Either SelectUserError (Id User, User))
-inMemoryGetUserByName userMap name' = liftIO . atomically $ do
-  users <- readTVar userMap
+inMemoryGetUserByName :: TVar (Map (Id User) User) -> Text -> Ctx (Id User, User)
+inMemoryGetUserByName userMap name' = do
+  users <- liftIO . atomically $ readTVar userMap
   let usersWithName = filter ((== name') . name) users
   case size usersWithName of
-    0 -> pure $ Left NoUser
-    1 -> pure . Right . head $ assocs usersWithName
-    _ -> pure $ Left MoreThanOneUser
+    0 -> throwError $ IncorrectNumberOfRows NoResults
+    1 -> pure . head . assocs $ usersWithName
+    _ -> throwError $ IncorrectNumberOfRows MoreThanOneResult
 
 duplicateNameError :: Text -> UserRepositoryError
 duplicateNameError name' =
@@ -47,7 +50,7 @@ duplicateNameError name' =
             Nothing
       )
 
-inMemoryAddUser :: TVar (Map (Id User) User) -> Text -> EncryptedPassword -> ExceptT UserRepositoryError IO (Id User)
+inMemoryAddUser :: TVar (Map (Id User) User) -> Text -> EncryptedPassword -> Ctx (Id User)
 inMemoryAddUser userMap name' password' = do
   userId <- Id <$> liftIO nextRandom
   queryError <- liftIO . atomically $ do

--- a/spec/InMemoryUserRepository.hs
+++ b/spec/InMemoryUserRepository.hs
@@ -7,10 +7,10 @@ import Data.Map.Lazy (Map, assocs, filter, insert, size)
 import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8)
 import Data.UUID.V4 (nextRandom)
-import GHC.Conc (TVar, atomically, readTVar, writeTVar)
+import GHC.Conc (TVar, atomically, readTVar, readTVarIO, writeTVar)
 import Hasql.Session (CommandError (ResultError), QueryError (QueryError), ResultError (ServerError))
 import Infrastructure.Persistence.PostgresUserRepository (UserRepositoryError (..))
-import Infrastructure.Persistence.Queries (WrongNumberOfRows (..))
+import Infrastructure.Persistence.Queries (WrongNumberOfResults (..))
 import PostgreSQL.ErrorCodes (unique_violation)
 import Tagger.EncryptedPassword (EncryptedPassword)
 import Tagger.Id (Id (Id))
@@ -18,23 +18,21 @@ import Tagger.User (User (..))
 import Tagger.UserRepository (UserRepository (..))
 import Prelude hiding (filter)
 
-type Ctx = ExceptT UserRepositoryError IO
-
-inMemoryUserRepository :: TVar (Map (Id User) User) -> UserRepository Ctx
+inMemoryUserRepository :: TVar (Map (Id User) User) -> UserRepository (ExceptT UserRepositoryError IO)
 inMemoryUserRepository userMap =
   UserRepository
     { getUserByName = inMemoryGetUserByName userMap,
       addUser = inMemoryAddUser userMap
     }
 
-inMemoryGetUserByName :: TVar (Map (Id User) User) -> Text -> Ctx (Id User, User)
+inMemoryGetUserByName :: TVar (Map (Id User) User) -> Text -> ExceptT UserRepositoryError IO (Id User, User)
 inMemoryGetUserByName userMap name' = do
-  users <- liftIO . atomically $ readTVar userMap
+  users <- liftIO $ readTVarIO userMap
   let usersWithName = filter ((== name') . name) users
   case size usersWithName of
-    0 -> throwError $ IncorrectNumberOfRows NoResults
+    0 -> throwError $ UnexpectedNumberOfRows NoResults
     1 -> pure . head . assocs $ usersWithName
-    _ -> throwError $ IncorrectNumberOfRows MoreThanOneResult
+    _ -> throwError $ UnexpectedNumberOfRows MoreThanOneResult
 
 duplicateNameError :: Text -> UserRepositoryError
 duplicateNameError name' =
@@ -50,7 +48,7 @@ duplicateNameError name' =
             Nothing
       )
 
-inMemoryAddUser :: TVar (Map (Id User) User) -> Text -> EncryptedPassword -> Ctx (Id User)
+inMemoryAddUser :: TVar (Map (Id User) User) -> Text -> EncryptedPassword -> ExceptT UserRepositoryError IO (Id User)
 inMemoryAddUser userMap name' password' = do
   userId <- Id <$> liftIO nextRandom
   queryError <- liftIO . atomically $ do

--- a/spec/TaggerSpec.hs
+++ b/spec/TaggerSpec.hs
@@ -88,7 +88,10 @@ spec = around withTaggerApp $ do
         response `shouldSatisfy` isRight
 
       it "does not generate a token for a non registered user" $ \port -> do
-        response <- runClientM ((login . authentication $ apiClient) (Credentials "marcosh" (Password "password"))) (clientEnv port)
+        let loginOperation = login . authentication $ apiClient
+            credentials = Credentials "marcosh" (Password "password")
+
+        response <- runClientM (loginOperation credentials) (clientEnv port)
         response `shouldSatisfy` hasStatus unauthorized401
 
     describe "addContent" $ do

--- a/src/Infrastructure/Authentication/AuthenticateUser.hs
+++ b/src/Infrastructure/Authentication/AuthenticateUser.hs
@@ -7,7 +7,7 @@ import Control.Monad.Trans.Except (ExceptT, throwE, withExceptT)
 import Infrastructure.Authentication.Credentials (Credentials (..))
 import Infrastructure.Authentication.PasswordManager (PasswordManager (validatePassword))
 import Infrastructure.Persistence.PostgresUserRepository (UserRepositoryError)
-import Infrastructure.Persistence.Queries (WrongNumberOfRows)
+import Infrastructure.Persistence.Queries (WrongNumberOfResults)
 import Tagger.Id (Id)
 import Tagger.User (User)
 import Tagger.UserRepository (UserRepository (getUserByName))
@@ -26,7 +26,7 @@ hoist f (AuthenticateUser auth) = AuthenticateUser $ f . auth
 -- How 'authenticateUser' can actually fail
 data AuthenticationError
   = -- | the provided 'Credentials' data do not correspond to a unique user
-    AuthenticationSelectUserError WrongNumberOfRows
+    AuthenticationSelectUserError WrongNumberOfResults
   | -- | the interaction with the database somehow failed
     AuthenticationQueryError UserRepositoryError
   | -- | the password provided in the 'Credentials' data is not correct

--- a/src/Infrastructure/Persistence/PostgresUserRepository.hs
+++ b/src/Infrastructure/Persistence/PostgresUserRepository.hs
@@ -1,55 +1,63 @@
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Infrastructure.Persistence.PostgresUserRepository where
 
-import Control.Arrow ((&&&))
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Trans.Except (ExceptT (ExceptT), withExceptT)
-import Data.Bifunctor (second)
+import Control.Monad.Trans.Except (ExceptT (ExceptT), throwE, withExceptT)
 import Data.ByteString (isInfixOf)
 import Data.Text (Text)
 import Data.UUID.V4 (nextRandom)
-import Hasql.Session (CommandError (ResultError), QueryError (QueryError), ResultError (ServerError))
+import Hasql.Session (CommandError (ResultError), QueryError (QueryError), ResultError (ServerError), Session)
 import qualified Infrastructure.Database as DB
-import qualified Infrastructure.Persistence.Queries as Query (addUser, selectUserByName)
+import Infrastructure.Persistence.Queries (WrongNumberOfRows)
+import qualified Infrastructure.Persistence.Queries as Query
 import Infrastructure.Persistence.Schema (litUser, userId)
 import Infrastructure.Persistence.Serializer (serializeUser, unserializeUser)
 import Tagger.EncryptedPassword (EncryptedPassword)
 import Tagger.Id (Id (Id))
 import Tagger.User (User (User))
-import Tagger.UserRepository (SelectUserError, UserRepository (..))
+import Tagger.UserRepository (UserRepository (..))
 
 -- We want to distinguish the `QueryError` coming from the violation of the "users_name_key" unique constraints
 data UserRepositoryError
   = DuplicateUserName QueryError
+  | IncorrectNumberOfRows WrongNumberOfRows
   | OtherError QueryError
   deriving (Show)
 
-liftAddUserError :: QueryError -> UserRepositoryError
-liftAddUserError queryError@(QueryError _ _ (ResultError (ServerError "23505" message _ _)))
-  | "users_name_key" `isInfixOf` message = DuplicateUserName queryError
-liftAddUserError queryError = OtherError queryError
-
 -- |
 -- A 'UserRepository' based on PostgreSQL
-postgresUserRepository :: DB.Handle -> UserRepository (ExceptT UserRepositoryError IO)
+postgresUserRepository :: DB.Handle -> UserRepository Ctx
 postgresUserRepository handle =
   UserRepository
     { getUserByName = postgresGetUserByName handle,
       addUser = postgresAddUser handle
     }
 
-postgresGetUserByName :: DB.Handle -> Text -> ExceptT UserRepositoryError IO (Either SelectUserError (Id User, User))
-postgresGetUserByName handle name = withExceptT OtherError . ExceptT $ do
-  -- Try to retrieve the user with the provided name from the database
-  eitherUser <- DB.runQuery handle (Query.selectUserByName name)
-  -- Adjust the happy path format
-  pure $ second (userId &&& unserializeUser) <$> eitherUser
+type Ctx = ExceptT UserRepositoryError IO
 
-postgresAddUser :: DB.Handle -> Text -> EncryptedPassword -> ExceptT UserRepositoryError IO (Id User)
+postgresGetUserByName :: DB.Handle -> Text -> Ctx (Id User, User)
+postgresGetUserByName handle name = do
+  eitherUser <- runQuery' handle (Query.selectUserByName name)
+  case eitherUser of
+    Right usr -> pure (userId usr, unserializeUser usr)
+    Left e -> throwE $ IncorrectNumberOfRows e
+
+postgresAddUser :: DB.Handle -> Text -> EncryptedPassword -> Ctx (Id User)
 postgresAddUser handle name password = do
   -- Generate the UUID for the user
   userId' <- liftIO nextRandom
+  let query = Query.addUser . litUser $ serializeUser (Id userId') (User name password)
+
   -- Actually add the user to the database, differentiating the `UserRepositoryError` cases
-  withExceptT liftAddUserError . ExceptT $ DB.runQuery handle (Query.addUser . litUser $ serializeUser (Id userId') (User name password))
+  runQuery' handle query
   pure $ Id userId'
+
+runQuery' :: DB.Handle -> Session a -> Ctx a
+runQuery' handle query = withExceptT liftAddUserError . ExceptT $ DB.runQuery handle query
+
+liftAddUserError :: QueryError -> UserRepositoryError
+liftAddUserError queryError@(QueryError _ _ (ResultError (ServerError "23505" message _ _)))
+  | "users_name_key" `isInfixOf` message = DuplicateUserName queryError
+liftAddUserError queryError = OtherError queryError

--- a/src/Infrastructure/Persistence/Queries.hs
+++ b/src/Infrastructure/Persistence/Queries.hs
@@ -115,27 +115,27 @@ addContentWithTags content tags = transaction Serializable Write $ do
   Transaction.statement () $ add contentSchema [litContent content]
   Transaction.statement () $ add contentsTagsSchema (contentTag (litContent content) <$> (litTag <$> alreadyPresentTags) <> newTags)
 
+-- SELECT USER BY USERNAME
+
 -- |
 -- Describes the possible error cases for queries that expect exactly one row as a result.
-data WrongNumberOfRows
+data WrongNumberOfResults
   = NoResults
   | MoreThanOneResult
   deriving (Show)
 
 -- |
 -- Given a list of results, succeed if there is only one in the list, otherwise fail with the appropriate error message
-justOne :: [a Result] -> Either WrongNumberOfRows (a Result)
+justOne :: [a Result] -> Either WrongNumberOfResults (a Result)
 justOne = \case
   [] -> Left NoResults
   [a] -> Right a
   _ -> Left MoreThanOneResult
 
--- SELECT USER BY USERNAME
-
 -- |
 -- Retrieve from the database a user with the provided name.
 -- If in the database we find none or more the one, it returns the appropriate error message
-selectUserByName :: Text -> Session (Either WrongNumberOfRows (User Result))
+selectUserByName :: Text -> Session (Either WrongNumberOfResults (User Result))
 selectUserByName name = statement () query
   where
     query = fmap justOne . select $ do

--- a/src/Tagger/UserRepository.hs
+++ b/src/Tagger/UserRepository.hs
@@ -9,21 +9,11 @@ import Tagger.Id (Id)
 import Tagger.User (User)
 
 -- |
--- When we 'getUserByName' we expect only one 'User' in return.
--- 'SelectUserError' describes how this can fail
-data SelectUserError
-  = -- | we are expecting one user, but actually no user is found
-    NoUser
-  | -- | we are expecting one user, but actually more than one user is found
-    MoreThanOneUser
-  deriving (Show)
-
--- |
 -- A 'UserRespository' represents a collection of 'User's.
 -- It is indexed by a context 'm' which wraps the results.
 data UserRepository m = UserRepository
   { -- | searches the repository for 'User's with the provided name
-    getUserByName :: Text -> m (Either SelectUserError (Id User, User)),
+    getUserByName :: Text -> m (Id User, User),
     -- | tries to add a user with the provided name and password
     addUser :: Text -> EncryptedPassword -> m (Id User)
   }


### PR DESCRIPTION
This PR stems from this one line change:

```diff
data UserRepository m = UserRepository
data UserRepository m = UserRepository
  { -- | searches the repository for 'User's with the provided name
-   getUserByName :: Text -> m (Either SelectUserError (Id User, User)),
+   getUserByName :: Text -> m (Id User, User),
    -- | tries to add a user with the provided name and password
    addUser :: Text -> EncryptedPassword -> m (Id User)
  }
  }
```

It's an exploration of defining the domain operations as directly as possible, pushing error handling out into the monadic context.