### PR TITLE
Move dependencies to Infrastructure module

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -9,8 +9,8 @@ import Api.Config (Port (..), apiPort)
 import qualified Api.Config as Config
 import CLIOptions (CLIOptions (configPath))
 import qualified CLIOptions
-import Dependencies (Deps (..))
-import qualified Dependencies as Deps
+import Infrastructure.Dependencies (Deps (..))
+import qualified Infrastructure.Dependencies as Deps
 import qualified Infrastructure.Logging.Logger as Logger
 import qualified Middleware
 import qualified Network.Wai.Handler.Warp as Warp

--- a/src/Infrastructure/Dependencies.hs
+++ b/src/Infrastructure/Dependencies.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE RecordWildCards #-}
-module Dependencies (withDeps, Deps (..)) where
+
+module Infrastructure.Dependencies (withDeps, Deps (..)) where
 
 import qualified Api.Config as Config
 import qualified Infrastructure.Database as DB


### PR DESCRIPTION
Since these are dependencies on services like database, logger, etc., it seems to me that the infrastructure module is a better place for them.