### PR TITLE
Fix HLS errors

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,3 +1,0 @@
-import Distribution.Simple
-
-main = defaultMain

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,7 @@
             elmPackages.elm-live
             elmPackages.elm-language-server
             haskellPackages.haskell-language-server
+            haskellPackages.hspec-discover
             haskellPackages.ormolu
             jq
             nodejs


### PR DESCRIPTION
Before:
```
$ haskell-language-server
Files that failed:
 * /home/cgeorgii/projects/tweag/servant-template/Setup.hs
 * /home/cgeorgii/projects/tweag/servant-template/spec/Spec.hs

Completed (36 files worked, 2 files failed)
```

After:
```
$ haskell-language-server
Completed (37 files worked, 0 files failed)
```

We don't need `Setup.hs` and adding the `hspec-discover` exec to the shell does the trick for the Spec error.