### PR TITLE
grant to database user all privileges on public schema

### DIFF
--- a/scripts/db/setup
+++ b/scripts/db/setup
@@ -28,6 +28,7 @@ then
 
   echo "[DB] Granting privileges to \"$dbuser\"..."
   psql --command "grant all privileges on database \"$dbname\" to \"$dbuser\";"
+  psql -d "$dbname" --command "grant all on schema public to \"$dbuser\""
 
   echo "[DB] Applying schema..."
   psql -U "$dbuser" -d "$dbname" -f ./schema.sql;


### PR DESCRIPTION
closes #65 

according to https://dba.stackexchange.com/a/338504/111429, it's not enough to grant the user all privileges on the database, but they need to receive also permission on the schema